### PR TITLE
feat: add support for atdw atlas api call

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+composer.lock

--- a/apps/api/app/ExternalAPIs/Atdw/Areas.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Areas.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Throwable;
+
+class Areas
+{
+    private readonly AtlasAPI $atlasAPI;
+
+    public function __construct()
+    {
+        $this->atlasAPI = new AtlasAPI();
+    }
+
+    /**
+     * @param string $byState
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(string $byState = 'NSW'): array
+    {
+        return $this->atlasAPI->get('areas', [
+            'st' => $byState
+        ]);
+    }
+}

--- a/apps/api/app/ExternalAPIs/Atdw/AtlasAPI.php
+++ b/apps/api/app/ExternalAPIs/Atdw/AtlasAPI.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Exception;
+use Throwable;
+
+class AtlasAPI
+{
+    private readonly Client $guzzleClient;
+
+    public function __construct()
+    {
+        $this->guzzleClient = new Client([
+            'base_uri' => config('atlas.url'),
+        ]);
+    }
+
+
+    /**
+     * @throws Throwable
+     * @throws GuzzleException
+     */
+    public function get(string $path, array $query = []): array
+    {
+        throw_if(empty($path), Exception::class, "Path cannot be empty");
+
+        $query = array_merge($query, ['key' => config('atlas.api_key'), 'out' => 'json']);
+
+        $path = trim($path, " /\n\r\t\v");
+        $response = $this->guzzleClient->get($path, [
+            'query' => $query
+        ]);
+
+        $result = json_decode(
+            iconv('UTF-16LE', 'UTF-8', (string)$response->getBody()),
+            true
+        );
+
+        return !blank($result) ? $result : [];
+    }
+}

--- a/apps/api/app/ExternalAPIs/Atdw/Regions.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Regions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Throwable;
+
+class Regions
+{
+    private readonly AtlasAPI $atlasAPI;
+
+    public function __construct()
+    {
+        $this->atlasAPI = new AtlasAPI();
+    }
+
+    /**
+     * @param string $byState
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(string $byState = 'NSW'): array
+    {
+        return $this->atlasAPI->get('regions', [
+            'st' => $byState
+        ]);
+    }
+}

--- a/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Throwable;
+
+class Suburbs
+{
+    private readonly AtlasAPI $atlasAPI;
+
+    public function __construct()
+    {
+        $this->atlasAPI = new AtlasAPI();
+    }
+
+    /**
+     * @param string $byState
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(string $byState = 'NSW'): array
+    {
+        $res = $this->atlasAPI->get('suburbs', [
+            'st' => $byState
+        ]);
+
+        return collect($res)->first() ?: [];
+    }
+}

--- a/apps/api/app/Providers/AtlasAPIServiceProvider.php
+++ b/apps/api/app/Providers/AtlasAPIServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Providers;
+
+use App\ExternalAPIs\Atdw\AtlasAPI;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+
+class AtlasAPIServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->configureURL();
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $this->app->singleton('atlas', function () {
+            return new AtlasAPI();
+        });
+    }
+
+    private function configureURL()
+    {
+        $uri = config('atlas.url');
+        if (blank($uri)) {
+            Log::error('Atlas URL is not configured');
+        }
+
+        if (!Str::endsWith($uri, '/')) {
+            $uri = config('atlas.url') . '/';
+            config(['atlas.url' => $uri]);
+        }
+    }
+}

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.5",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "ext-iconv": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/apps/api/config/app.php
+++ b/apps/api/config/app.php
@@ -190,6 +190,7 @@ return [
          * Application Service Providers...
          */
         App\Providers\AppServiceProvider::class,
+        App\Providers\AtlasAPIServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,

--- a/apps/api/config/atlas.php
+++ b/apps/api/config/atlas.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    /*
+     * The url for the ATDW Atlas API.
+     */
+    "url" => "atlas.atdw-online.com.au/api/atlas",
+
+
+    /*
+     * The ATDW Atlas API key.
+     */
+    "api_key" => env("ATLAS_API_KEY", null),
+];


### PR DESCRIPTION
#### Title: Add support for ATDW Atlas API call

Description:

This pull request adds support for the ATDW Atlas API call to the application. The ATDW Atlas API provides access to Australian tourism data.

To implement this feature, I added a new module to the application that interfaces with the ATDW Atlas API. I also updated the application's configuration files to allow users to easily configure the API credentials.

Only the following API calls are implemented:

- Areas
- Regions
- Suburbs