### PR TITLE
feat(api): add areas endpoint

### DIFF
--- a/apps/api/app/Http/Controllers/AreasController.php
+++ b/apps/api/app/Http/Controllers/AreasController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Filters\SearchAreaRequest;
+use App\Http\Resources\Filters\AreaResource;
+use App\Services\Filters\AreaService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
+
+class AreasController extends Controller
+{
+    public function __construct(private readonly AreaService $service)
+    {
+    }
+
+    public function index(SearchAreaRequest $request): AnonymousResourceCollection | JsonResponse
+    {
+        try {
+            $searchable = $request->validated();
+            $res = $this->service->search($searchable);
+
+            return AreaResource::collection($res);
+        } catch (Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/apps/api/app/Http/Requests/Filters/SearchAreaRequest.php
+++ b/apps/api/app/Http/Requests/Filters/SearchAreaRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Filters;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchAreaRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'string|nullable',
+            'state' => 'string|nullable',
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/Filters/AreaResource.php
+++ b/apps/api/app/Http/Resources/Filters/AreaResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Filters;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AreaResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this['AreaId'],
+            'code' => $this['Code'],
+            'name' => $this['Name'],
+            'type' => $this['Type'],
+            'state' => $this['StateCode'],
+        ];
+    }
+}

--- a/apps/api/app/Services/Filters/AreaService.php
+++ b/apps/api/app/Services/Filters/AreaService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\Filters;
+
+use App\ExternalAPIs\Atdw\Areas;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Throwable;
+
+class AreaService
+{
+    public function __construct(private readonly Areas $api)
+    {
+    }
+
+    /**
+     * @param array $searchable
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function search(array $searchable): array
+    {
+        $state = $searchable['state'] ?? 'NSW';
+        $name = $searchable['name'] ?? null;
+
+        $areas = Cache::remember('areas', 60, function () use ($state) {
+            $result = $this->api->fetch($state);
+            return collect($result)
+                ->sortBy('Name')
+                ->values()
+                ->toArray();
+        });
+
+        if ($name) {
+            $areas = collect($areas)
+                ->filter(fn($area) =>  Str::contains($area['Name'], $name, true))
+                ->values()
+                ->toArray();
+        }
+
+        return $areas;
+    }
+}

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -16,7 +16,7 @@
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",
-        "mockery/mockery": "^1.4.4",
+        "mockery/mockery": "^1.5",
         "nunomaduro/collision": "^6.4",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.2",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3ba2ce98eb40488b36826b4c6064b11",
+    "content-hash": "f230934a60fe0ec4ada86acb27d493c2",
     "packages": [
         {
             "name": "brick/math",
@@ -8186,7 +8186,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "ext-simplexml": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -21,32 +21,7 @@ services:
         networks:
             - otivo
         depends_on:
-            - mariadb
             - redis
-    mariadb:
-        image: 'mariadb:10'
-        ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
-        environment:
-            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ROOT_HOST: '%'
-            MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        volumes:
-            - 'otivo-mariadb:/var/lib/mysql'
-            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
-        networks:
-            - otivo
-        healthcheck:
-            test:
-                - CMD
-                - mysqladmin
-                - ping
-                - '-p${DB_PASSWORD}'
-            retries: 3
-            timeout: 5s
     redis:
         image: 'redis:alpine'
         ports:
@@ -66,7 +41,5 @@ networks:
     otivo:
         driver: bridge
 volumes:
-    otivo-mariadb:
-        driver: local
     otivo-redis:
         driver: local

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -17,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/areas', [App\Http\Controllers\AreasController::class, 'index']);

--- a/apps/api/tests/Feature/Api/Filter/AreasAPITest.php
+++ b/apps/api/tests/Feature/Api/Filter/AreasAPITest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\ExternalAPIs\Atdw\Areas;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+afterAll(function () {
+    Mockery::close();
+});
+
+it('has api/areas endpoint', function () {
+    $mock = Mockery::mock(Areas::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([]);
+    });
+
+    $this->app->instance(Areas::class, $mock);
+
+    $this->get('/api/areas')
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+});
+
+
+it('returns all areas', function () {
+    $mock = Mockery::mock(Areas::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['AreaId' => '001', 'Name' => 'Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '002', 'Name' => 'Sydney West', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '003', 'Name' => 'Sydney East', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '004', 'Name' => 'Inner Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '005', 'Name' => 'Sydney South', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '006', 'Name' => 'North Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '007', 'Name' => 'Sydney South-West', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW']
+            ]);
+    });
+    $this->app->instance(Areas::class, $mock);
+
+    $response = $this->get('/api/areas');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(7);
+});
+
+it('only returns areas with name contains "inn" when searched by name', function () {
+    $mock = Mockery::mock(Areas::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['AreaId' => '001', 'Name' => 'Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '004', 'Name' => 'Inner Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW'],
+                ['AreaId' => '006', 'Name' => 'North Sydney', 'Code' => 'SYD', 'Type' => 'LOCAL', 'StateCode' => 'NSW']
+            ]);
+    });
+    $this->app->instance(Areas::class, $mock);
+
+    $response = $this->get('/api/areas?name=Inn');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));;
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(1);
+});


### PR DESCRIPTION
#### Title: Add areas API endpoint from ATDW Atlas areas API call

**Description**:
This PR adds a new endpoint to the API that allows clients to retrieve a list of all available areas.

The new endpoint is accessible via the URL `/areas`, and returns a JSON array of objects, each representing an area. Each area object contains the following fields:

    id: a unique identifier for the area
    name: the name of the area
    code: a 3 char code of the area
    type: the type of the area. i.e: LOCAL
    state: a 3 char code of the state. i.e: NSW

 The `/areas` endpoint retrieves the data from the ATDW Atlas API and returns it in JSON format. The data **cached** every **60** seconds.

Tests have been added to ensure that the endpoint returns the expected data.