### PR TITLE
feat(api): add regions api endpoint

### DIFF
--- a/apps/api/app/Http/Controllers/RegionsController.php
+++ b/apps/api/app/Http/Controllers/RegionsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Filters\SearchRegionRequest;
+use App\Http\Resources\Filters\RegionResource;
+use App\Services\Filters\RegionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
+
+class RegionsController extends Controller
+{
+    public function __construct(private readonly RegionService $service)
+    {
+    }
+
+    public function index(SearchRegionRequest $request): AnonymousResourceCollection|JsonResponse
+    {
+        try {
+            $searchable = $request->validated();
+            $res = $this->service->search($searchable);
+
+            return RegionResource::collection($res);
+        } catch (Throwable $e) {
+            return response()->json([
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/apps/api/app/Http/Requests/Filters/SearchRegionRequest.php
+++ b/apps/api/app/Http/Requests/Filters/SearchRegionRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Filters;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRegionRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'string|nullable',
+            'state' => 'string|nullable',
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/Filters/RegionResource.php
+++ b/apps/api/app/Http/Resources/Filters/RegionResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Filters;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RegionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this['RegionId'],
+            'code' => $this['Code'],
+            'name' => $this['Name'],
+            'type' => $this['Type'],
+            'state' => $this['State'],
+        ];
+    }
+}

--- a/apps/api/app/Services/Filters/RegionService.php
+++ b/apps/api/app/Services/Filters/RegionService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Filters;
+
+use App\ExternalAPIs\Atdw\Regions;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Throwable;
+
+class RegionService
+{
+    public function __construct(private readonly Regions $api)
+    {
+    }
+
+    /**
+     * @throws GuzzleException | Throwable
+     */
+    public function search(array $searchable): array
+    {
+        $state = $searchable['state'] ?? 'NSW';
+        $name = $searchable['name'] ?? null;
+
+        $regions = Cache::remember('regions', 60, function () use ($state) {
+            $result = $this->api->fetch($state);
+            return collect($result)
+                ->sortBy('Name')
+                ->values()
+                ->toArray();
+        });
+
+        if ($name) {
+            $regions = collect($regions)
+                ->filter(fn($region) =>  Str::contains($region['Name'], $name, true))
+                ->values()
+                ->toArray();
+        }
+
+        return $regions;
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -19,3 +19,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::get('/areas', [App\Http\Controllers\AreasController::class, 'index']);
+Route::get('/regions', [App\Http\Controllers\RegionsController::class, 'index']);

--- a/apps/api/tests/Feature/Api/Filter/RegionsAPITest.php
+++ b/apps/api/tests/Feature/Api/Filter/RegionsAPITest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\ExternalAPIs\Atdw\Regions;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+afterAll(function () {
+    Mockery::close();
+});
+
+it('has api/regions endpoint', function () {
+    $mock = Mockery::mock(Regions::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([]);
+    });
+
+    $this->app->instance(Regions::class, $mock);
+
+    $this->get('/api/regions')
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+});
+
+
+it('returns all regions', function () {
+    $mock = Mockery::mock(Regions::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['RegionId' => '001', 'Name' => 'North Coast', 'Code' => 'NCT', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '002', 'Name' => 'Central Coast', 'Code' => 'CCT', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '003', 'Name' => 'Hunter', 'Code' => 'HUN', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '004', 'Name' => 'Newcastle', 'Code' => 'NEW', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '005', 'Name' => 'Sydney', 'Code' => 'SYD', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '006', 'Name' => 'Illawarra', 'Code' => 'ILL', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '007', 'Name' => 'South Coast', 'Code' => 'SCT', 'Type' => 'MARKETING', 'State' => 'NSW']
+            ]);
+    });
+    $this->app->instance(Regions::class, $mock);
+
+    $response = $this->get('/api/regions');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(7);
+});
+
+it('only returns regions with name contains "inn" when searched by name', function () {
+    $mock = Mockery::mock(Regions::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['RegionId' => '001', 'Name' => 'North Coast', 'Code' => 'NCT', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '003', 'Name' => 'Hunter', 'Code' => 'HUN', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '004', 'Name' => 'Newcastle', 'Code' => 'NEW', 'Type' => 'MARKETING', 'State' => 'NSW'],
+                ['RegionId' => '006', 'Name' => 'Illawarra', 'Code' => 'ILL', 'Type' => 'MARKETING', 'State' => 'NSW'],
+            ]);
+    });
+    $this->app->instance(Regions::class, $mock);
+
+    $response = $this->get('/api/regions?name=New');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));;
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(1);
+});


### PR DESCRIPTION

#### Title: Add regions API endpoint from ATDW Atlas areas API call

**Description:**

This PR adds a new endpoint to the API that allows clients to retrieve a list of all available regions.

The new endpoint is accessible via the URL `/regions`, and returns a JSON array of objects, each representing a region. Each area object contains the following fields:
    
    id: a unique identifier for the region
    name: the name of the region
    code: a 3 char code of the region
    type: the type of the area. i.e: MARKETING
    state: a 3 char code of the state. i.e: NSW

The `/regions` endpoint retrieves the data from the ATDW Atlas API and returns it in JSON format. The data cached every 60 seconds.

Tests have been added to ensure that the endpoint returns the expected data.