### PR TITLE
feat(api): add suburbs api endpoint

### DIFF
--- a/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
@@ -25,6 +25,6 @@ class Suburbs
             'st' => $byState
         ]);
 
-        return collect($res)->first() ?: [];
+        return collect($res)->first()['Suburbs'] ?? [];
     }
 }

--- a/apps/api/app/Http/Controllers/SuburbsController.php
+++ b/apps/api/app/Http/Controllers/SuburbsController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Filters\SearchSuburbRequest;
+use App\Http\Resources\Filters\SuburbResource;
+use App\Services\Filters\SuburbService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
+
+class SuburbsController extends Controller
+{
+    public function __construct(private readonly SuburbService $service)
+    {
+    }
+
+    public function index(SearchSuburbRequest $request): AnonymousResourceCollection|JsonResponse
+    {
+        try {
+            $searchable = $request->validated();
+            $res = $this->service->search($searchable);
+
+            return SuburbResource::collection($res);
+        } catch (Throwable $e) {
+            return response()->json([
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/apps/api/app/Http/Requests/Filters/SearchSuburbRequest.php
+++ b/apps/api/app/Http/Requests/Filters/SearchSuburbRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Filters;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchSuburbRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'string|nullable',
+            'state' => 'string|nullable',
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/Filters/SuburbResource.php
+++ b/apps/api/app/Http/Resources/Filters/SuburbResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Filters;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SuburbResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this['SuburbId'],
+            'name' => $this['Name'],
+            'postcode' => $this['PostCode'],
+        ];
+    }
+}

--- a/apps/api/app/Services/Filters/SuburbService.php
+++ b/apps/api/app/Services/Filters/SuburbService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\Filters;
+
+use App\ExternalAPIs\Atdw\Suburbs;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Throwable;
+
+class SuburbService
+{
+    public function __construct(private readonly Suburbs $api)
+    {
+    }
+
+    /**
+     * @param array $searchable
+     * @throws GuzzleException | Throwable
+     * @return array
+     */
+    public function search(array $searchable): array
+    {
+        $state = $searchable['state'] ?? 'NSW';
+        $name = $searchable['name'] ?? null;
+        $suburbs = Cache::remember('suburbs', 60, function () use ($state) {
+            $result = $this->api->fetch($state);
+            return collect($result)
+                ->filter(fn($suburb) => !empty($suburb['Name']))
+                ->sortBy('Name')
+                ->values()
+                ->toArray();
+        });
+
+        if ($name) {
+            $suburbs = collect($suburbs)
+                ->filter(fn($suburb) =>  Str::contains($suburb['Name'], $name, true))
+                ->values()
+                ->toArray();
+        }
+
+        return $suburbs;
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::get('/areas', [App\Http\Controllers\AreasController::class, 'index']);
 Route::get('/regions', [App\Http\Controllers\RegionsController::class, 'index']);
+Route::get('/suburbs', [App\Http\Controllers\SuburbsController::class, 'index']);

--- a/apps/api/tests/Feature/Api/Filter/SuburbsAPITest.php
+++ b/apps/api/tests/Feature/Api/Filter/SuburbsAPITest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\ExternalAPIs\Atdw\Suburbs;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+afterAll(function () {
+    Mockery::close();
+});
+
+it('has api/suburbs endpoint', function () {
+    $mock = Mockery::mock(Suburbs::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([]);
+    });
+
+    $this->app->instance(Suburbs::class, $mock);
+
+    $this->get('/api/suburbs')
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+});
+
+
+it('returns all suburbs', function () {
+    $mock = Mockery::mock(Suburbs::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['SuburbId' => '001', 'Name' => 'Aarons Pass', 'PostCode' => '2850'],
+                ['SuburbId' => '002', 'Name' => 'Abbotsbury', 'PostCode' => '2176'],
+                ['SuburbId' => '004', 'Name' => 'Abercrombie', 'PostCode' => '2795'],
+                ['SuburbId' => '005', 'Name' => 'Doubtful Creek', 'PostCode' => '2470'],
+                ['SuburbId' => '006', 'Name' => 'East Lindfield', 'PostCode' => '2070'],
+                ['SuburbId' => '007', 'Name' => 'East Lismore', 'PostCode' => '2480'],
+            ]);
+    });
+    $this->app->instance(Suburbs::class, $mock);
+
+    $response = $this->get('/api/suburbs');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(6);
+});
+
+it('only returns suburbs with name contains "East" when searched by name', function () {
+    $mock = Mockery::mock(Suburbs::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                ['SuburbId' => '004', 'Name' => 'Abercrombie', 'PostCode' => '2795'],
+                ['SuburbId' => '005', 'Name' => 'Doubtful Creek', 'PostCode' => '2470'],
+                ['SuburbId' => '006', 'Name' => 'East Lindfield', 'PostCode' => '2070'],
+                ['SuburbId' => '007', 'Name' => 'East Lismore', 'PostCode' => '2480'],
+            ]);
+    });
+    $this->app->instance(Suburbs::class, $mock);
+
+    $response = $this->get('/api/suburbs?name=East');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));;
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(2);
+});


### PR DESCRIPTION

####Title: Add suburbs API endpoint from ATDW Atlas areas API call

**Description:**

This PR adds a new endpoint to the API that allows clients to retrieve a list of all available suburbs.

The new endpoint is accessible via the URL `/api/suburbs`, and returns a JSON array of objects, each representing a region. Each area object contains the following fields:

    id: an unique identifier for the suburbs
    name: the name of the suburbs
    postcode: a 4 digit code of the suburbs

The `/api/suburbs` endpoint retrieves the data from the ATDW Atlas API and returns it in JSON format. The data cached every 60 seconds.

Tests have been added to ensure that the endpoint returns the expected data.
