### PR TITLE
feat(api): add locations api endpoint

### DIFF
--- a/apps/api/app/ExternalAPIs/Atdw/Locations.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Locations.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Throwable;
+
+class Locations
+{
+    private readonly AtlasAPI $atlasAPI;
+
+    public function __construct()
+    {
+        $this->atlasAPI = new AtlasAPI();
+    }
+
+    /**
+     * @param string $byState
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(string $byState = 'NSW'): array
+    {
+        return $this->atlasAPI->get('locations', [
+            'st' => $byState
+        ]);
+    }
+}

--- a/apps/api/app/Http/Controllers/LocationController.php
+++ b/apps/api/app/Http/Controllers/LocationController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Filters\SearchLocationRequest;
+use App\Http\Resources\Filters\AreaResource;
+use App\Http\Resources\Filters\SuburbResource;
+use App\Services\Filters\LocationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
+
+class LocationController extends Controller
+{
+    public function __construct(private readonly LocationService $service)
+    {
+    }
+
+    public function index(SearchLocationRequest $request): AnonymousResourceCollection|JsonResponse
+    {
+        try {
+            $searchable = $request->validated();
+            $locations = $this->service->search($searchable);
+
+            if ($request->get('filter') === 'area') {
+                return AreaResource::collection($locations);
+            } elseif ($request->get('filter') === 'suburb') {
+                return SuburbResource::collection($locations);
+            }
+
+            return response()->json(['message' => 'Invalid filter provided'], 400);
+        } catch (Throwable $e) {
+            return response()->json(['message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/apps/api/app/Http/Requests/Filters/SearchLocationRequest.php
+++ b/apps/api/app/Http/Requests/Filters/SearchLocationRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Filters;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchLocationRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'filter' => 'string|required|in:area,suburb',
+            'region' => 'string|nullable',
+            'state' => 'string|nullable',
+        ];
+    }
+}

--- a/apps/api/app/Services/Filters/LocationService.php
+++ b/apps/api/app/Services/Filters/LocationService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services\Filters;
+
+use App\ExternalAPIs\Atdw\Locations;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Throwable;
+use Exception;
+
+class LocationService
+{
+    public function __construct(private readonly Locations $api)
+    {
+    }
+
+    /**
+     * @param array $searchable
+     * @throws GuzzleException | Throwable
+     * @return array
+     */
+    public function search(array $searchable): array
+    {
+        $state = $searchable['state'] ?? 'NSW';
+        $region = $searchable['region'] ?? 'Greater Sydney';
+        $filter = $searchable['filter'] ?? null;
+
+        $locations = Cache::remember('locations', 60, function () use ($state, $region) {
+            $result = $this->api->fetch($state);
+            return collect($result)
+                ->filter(fn($location) => Str::contains($location['DomesticRegionName'], $region, true))
+                ->sortBy('Name')
+                ->values()
+                ->toArray();
+        });
+
+        throw_if(empty($filter), Exception::class, 'No filter provided');
+
+        if($filter === 'area') {
+            $locations = collect($locations)
+                ->map(fn($location) => [
+                    "AreaId" => $location['AreaId'],
+                    "Code" => $location['Code'],
+                    "Name" => $location['Name'],
+                    "Type" => $location['Type'],
+                    "StateCode" => $location['StateCode'],
+                ])
+                ->values()
+                ->toArray();
+        } elseif ($filter === 'suburb') {
+            $locations = collect($locations)
+                ->map(fn($location) => [
+                    "Suburbs" => $location['Suburbs']["suburb"],
+                ])
+                ->flatMap(fn($location) => $location['Suburbs'])
+                ->values()
+                ->toArray();
+        }
+
+        return $locations;
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -21,3 +21,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::get('/areas', [App\Http\Controllers\AreasController::class, 'index']);
 Route::get('/regions', [App\Http\Controllers\RegionsController::class, 'index']);
 Route::get('/suburbs', [App\Http\Controllers\SuburbsController::class, 'index']);
+Route::get('/locations', [App\Http\Controllers\LocationController::class, 'index']);

--- a/apps/api/tests/Feature/Api/Filter/LocationsTest.php
+++ b/apps/api/tests/Feature/Api/Filter/LocationsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\ExternalAPIs\Atdw\Locations;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+afterAll(function () {
+    Mockery::close();
+});
+
+it('has api/locations page', function () {
+    $mock = Mockery::mock(Locations::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([]);
+    });
+
+    $this->app->instance(Locations::class, $mock);
+
+    $this->get('/api/locations?filter=area')
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+});
+
+it('returns areas only when filter value is set to area', function () {
+    $mock = Mockery::mock(Locations::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                [
+                    "AreaId" => "29000677",
+                    "Code" => "ISY",
+                    "Name" => "Inner Sydney",
+                    "Type" => "LOCAL",
+                    "DomesticRegionId" => 29000013,
+                    "DomesticRegionName" => "Greater Sydney",
+                    "StateId" => 9000002,
+                    "StateCode" => "NSW",
+                    "Suburbs" => [
+                        "suburb" => [
+                            [
+                                "SuburbId" => "29014839",
+                                "Name" => "Abbotsford",
+                                "PostCode" => "2046"
+                            ],
+                            [
+                                "SuburbId" => "29014840",
+                                "Name" => "Alexandria",
+                                "PostCode" => "2015"
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+    });
+
+    $this->app->instance(Locations::class, $mock);
+
+    $response = $this->get('/api/locations?filter=area');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(1);
+});
+
+
+it('returns suburbs only when filter value is set to suburb', function () {
+    $mock = Mockery::mock(Locations::class, function ($mock) {
+        $mock->shouldReceive('fetch')
+            ->once()
+            ->andReturn([
+                [
+                    "AreaId" => "29000677",
+                    "Code" => "ISY",
+                    "Name" => "Inner Sydney",
+                    "Type" => "LOCAL",
+                    "DomesticRegionId" => 29000013,
+                    "DomesticRegionName" => "Greater Sydney",
+                    "StateId" => 9000002,
+                    "StateCode" => "NSW",
+                    "Suburbs" => [
+                        "suburb" => [
+                            [
+                                "SuburbId" => "29014839",
+                                "Name" => "Abbotsford",
+                                "PostCode" => "2046"
+                            ],
+                            [
+                                "SuburbId" => "29014840",
+                                "Name" => "Alexandria",
+                                "PostCode" => "2015"
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+    });
+
+    $this->app->instance(Locations::class, $mock);
+
+    $response = $this->get('/api/locations?filter=suburb');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson(fn(AssertableJson $json) => $json->has('data'));
+
+    expect($response->getData()->data)
+        ->toBeArray()
+        ->toHaveCount(2);
+});


### PR DESCRIPTION
#### Title: Add suburbs API endpoint from ATDW Atlas areas API call

**Description:**

This PR adds a new endpoint to the API that allows clients to retrieve a list of all available suburbs or areas.

The new endpoint is accessible via the URL `/api/locations`, and returns a JSON array of objects based on the filter passed in the request body. The value of filter parameter is either area or suburb. 

The `/api/locations` endpoint retrieves the data from the ATDW Atlas API and returns it in JSON format. The data cached every 60 seconds.

Tests have been added to ensure that the endpoint returns the expected data.
