### PR TITLE
feat(products): create products endpoints

### DIFF
--- a/apps/api/app/ExternalAPIs/Atdw/Areas.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Areas.php
@@ -7,11 +7,8 @@ use Throwable;
 
 class Areas
 {
-    private readonly AtlasAPI $atlasAPI;
-
-    public function __construct()
+    public function __construct(private readonly AtlasAPI $atlasAPI)
     {
-        $this->atlasAPI = new AtlasAPI();
     }
 
     /**

--- a/apps/api/app/ExternalAPIs/Atdw/AtlasAPI.php
+++ b/apps/api/app/ExternalAPIs/Atdw/AtlasAPI.php
@@ -9,13 +9,8 @@ use Throwable;
 
 class AtlasAPI
 {
-    private readonly Client $guzzleClient;
-
-    public function __construct()
+    public function __construct(private readonly Client $guzzleClient)
     {
-        $this->guzzleClient = new Client([
-            'base_uri' => config('atlas.url'),
-        ]);
     }
 
 

--- a/apps/api/app/ExternalAPIs/Atdw/Locations.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Locations.php
@@ -7,11 +7,8 @@ use Throwable;
 
 class Locations
 {
-    private readonly AtlasAPI $atlasAPI;
-
-    public function __construct()
+    public function __construct(private readonly AtlasAPI $atlasAPI)
     {
-        $this->atlasAPI = new AtlasAPI();
     }
 
     /**

--- a/apps/api/app/ExternalAPIs/Atdw/Products.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Products.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\ExternalAPIs\Atdw;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Throwable;
+
+class Products
+{
+    public function __construct(private readonly AtlasAPI $atlasAPI)
+    {
+    }
+
+    /**
+     * @param array $filters
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(array $filters = []): array
+    {
+        $filters = array_filter($filters, fn($value) => !empty($value));
+        $response = $this->atlasAPI->get('products', $filters);
+
+        return $response['products'] ?? [];
+    }
+
+    /**
+     * @param string $id
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetchById(string $id): array
+    {
+        return $this->atlasAPI->get('product', [
+            'productId' => $id
+        ]);
+    }
+}

--- a/apps/api/app/ExternalAPIs/Atdw/Regions.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Regions.php
@@ -7,11 +7,8 @@ use Throwable;
 
 class Regions
 {
-    private readonly AtlasAPI $atlasAPI;
-
-    public function __construct()
+    public function __construct(private readonly AtlasAPI $atlasAPI)
     {
-        $this->atlasAPI = new AtlasAPI();
     }
 
     /**

--- a/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
+++ b/apps/api/app/ExternalAPIs/Atdw/Suburbs.php
@@ -7,11 +7,8 @@ use Throwable;
 
 class Suburbs
 {
-    private readonly AtlasAPI $atlasAPI;
-
-    public function __construct()
+    public function __construct(private readonly AtlasAPI $atlasAPI)
     {
-        $this->atlasAPI = new AtlasAPI();
     }
 
     /**

--- a/apps/api/app/Http/Controllers/ProductsController.php
+++ b/apps/api/app/Http/Controllers/ProductsController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SearchProductRequest;
+use App\Http\Resources\FullProductResource;
+use App\Http\Resources\ProductResource;
+use App\Services\Filters\ProductService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
+
+class ProductsController extends Controller
+{
+    public function __construct(private readonly ProductService $service)
+    {
+    }
+
+    public function index(SearchProductRequest $request): AnonymousResourceCollection|JsonResponse
+    {
+        try {
+            $filters = $request->validated();
+            $products = $this->service->fetch($filters);
+
+            return ProductResource::collection($products);
+        } catch (Throwable $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function show(string $id): FullProductResource|JsonResponse
+    {
+        try {
+            $product = $this->service->fetchById($id);
+
+            return new FullProductResource($product);
+        } catch (Throwable $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/apps/api/app/Http/Requests/SearchProductRequest.php
+++ b/apps/api/app/Http/Requests/SearchProductRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchProductRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'state' => 'string|nullable',
+            'category' => 'string|nullable',
+            'region' => 'string|nullable',
+            'regionId' => 'string|nullable',
+            'suburb' => 'string|nullable',
+            'suburbId' => 'string|nullable',
+            'area' => 'string|nullable',
+            'areaId' => 'string|nullable',
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/FullProductResource.php
+++ b/apps/api/app/Http/Resources/FullProductResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FullProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/apps/api/app/Http/Resources/ProductResource.php
+++ b/apps/api/app/Http/Resources/ProductResource.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this['productId'],
+            'name' => $this['productName'],
+            'status' => $this['status'],
+            'organisation_name' => $this['owningOrganisationName'],
+            'atw_expiry_date' => $this['atdwExpiryDate'],
+            'updated_at' => $this['productUpdateDate'],
+            'description' => $this['productDescription'],
+            'image' => $this['productImage'],
+            'geo_points' => $this['boundary'],
+            'address' => $this->formatAddress($this['addresses'][0] ?? []),
+            'score' => $this['score'],
+        ];
+    }
+
+    private function formatAddress(array $address): array
+    {
+        return [
+            'city' => $address['city'] ?? '',
+            'state' => $address['state'] ?? '',
+            'country' => $address['country'] ?? '',
+            'postcode' => $address['postcode'] ?? '',
+            'area' => $address['area'][0] ?? '',
+            'region' => $address['region'][0] ?? ''
+        ];
+    }
+}

--- a/apps/api/app/Providers/AtlasAPIServiceProvider.php
+++ b/apps/api/app/Providers/AtlasAPIServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\ExternalAPIs\Atdw\AtlasAPI;
+use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -22,8 +23,15 @@ class AtlasAPIServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->app->singleton('atlas', function () {
-            return new AtlasAPI();
+        $guzzleClient = new Client([
+            'base_uri' => config('atlas.url'),
+        ]);
+        $service = new AtlasAPI($guzzleClient);
+
+        $this->app->instance(AtlasAPI::class, $service);
+
+        $this->app->singleton('atlas', function () use ($guzzleClient) {
+            return new AtlasAPI($guzzleClient);
         });
     }
 

--- a/apps/api/app/Services/Filters/ProductService.php
+++ b/apps/api/app/Services/Filters/ProductService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services\Filters;
+
+use App\ExternalAPIs\Atdw\Products;
+use App\Services\Pipes\ApplyAreaFilter;
+use App\Services\Pipes\ApplyDefaultProductFilters;
+use App\Services\Pipes\ApplyRegionFilter;
+use App\Services\Pipes\ApplySuburbFilter;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Pipeline\Pipeline;
+use Throwable;
+
+class ProductService
+{
+    public function __construct(private readonly Products $api)
+    {
+    }
+
+    /**
+     * @param array<string, string> $filters
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetch(array $filters): array
+    {
+        return app(Pipeline::class)
+            ->send($filters)
+            ->through([
+                ApplyDefaultProductFilters::class,
+                ApplyRegionFilter::class,
+                ApplyAreaFilter::class,
+                ApplySuburbFilter::class,
+            ])
+            ->then(fn(array $filters) => $this->api->fetch($filters));
+    }
+
+    /**
+     * @param string $id
+     * @return array
+     * @throws GuzzleException | Throwable
+     */
+    public function fetchById(string $id): array
+    {
+        return $this->api->fetchById($id);
+    }
+}

--- a/apps/api/app/Services/Pipes/ApplyAreaFilter.php
+++ b/apps/api/app/Services/Pipes/ApplyAreaFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Pipes;
+
+use Closure;
+
+class ApplyAreaFilter
+{
+    public function handle(array $filters, Closure $next): array
+    {
+        if (isset($filters['area'])) {
+            $filters['ar'] = $filters['area'] ?? null;
+            unset($filters['area']);
+        }
+
+        if (isset($filters['areaId'])) {
+            $filters['servicear'] = $filters['areaId'] ?? null;
+            unset($filters['areaId']);
+        }
+
+        return $next($filters);
+    }
+}

--- a/apps/api/app/Services/Pipes/ApplyDefaultProductFilters.php
+++ b/apps/api/app/Services/Pipes/ApplyDefaultProductFilters.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Pipes;
+
+use Closure;
+
+class ApplyDefaultProductFilters
+{
+    public function handle(array $filters, Closure $next): array
+    {
+        $filters['st'] = $filters['state'] ?? 'NSW';
+        if (isset($filters['state'])) {
+            unset($filters['state']);
+        }
+
+        $filters['cats'] = $filters['category'] ?? 'ACCOMM';
+        if (isset($filters['category'])) {
+            unset($filters['category']);
+        }
+
+        return $next($filters);
+    }
+}

--- a/apps/api/app/Services/Pipes/ApplyRegionFilter.php
+++ b/apps/api/app/Services/Pipes/ApplyRegionFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Pipes;
+
+use Closure;
+
+class ApplyRegionFilter
+{
+    public function handle(array $filters, Closure $next): array
+    {
+        $filters['rg'] = $filters['region'] ?? 'Greater Sydney';
+        if (isset($filters['region'])) {
+            unset($filters['region']);
+        }
+
+        if (isset($filters['regionId'])) {
+            $filters['servicerg'] = $filters['regionId'] ?? null;
+            unset($filters['regionId']);
+        }
+
+        return $next($filters);
+    }
+}

--- a/apps/api/app/Services/Pipes/ApplySuburbFilter.php
+++ b/apps/api/app/Services/Pipes/ApplySuburbFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Pipes;
+
+use Closure;
+
+class ApplySuburbFilter
+{
+    public function handle(array $filters, Closure $next): array
+    {
+        if (isset($filters['suburb'])) {
+            $filters['ct'] = $filters['suburb'] ?? null;
+            unset($filters['suburb']);
+        }
+
+        if (isset($filters['suburbId'])) {
+            $filters['servicect'] = $filters['suburbId'] ?? null;
+            unset($filters['suburbId']);
+        }
+
+        return $next($filters);
+    }
+}

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -22,3 +22,4 @@ Route::get('/areas', [App\Http\Controllers\AreasController::class, 'index']);
 Route::get('/regions', [App\Http\Controllers\RegionsController::class, 'index']);
 Route::get('/suburbs', [App\Http\Controllers\SuburbsController::class, 'index']);
 Route::get('/locations', [App\Http\Controllers\LocationController::class, 'index']);
+Route::resource('/products', App\Http\Controllers\ProductsController::class)->only(['index', 'show']);


### PR DESCRIPTION
#### Title: Add products endpoints from ATDW Atlas areas API call

**Description:**

This PR adds a new endpoint to the API that allows clients to retrieve a list of all accommodation.

Two endpoints are created

- `/api/products` : returns list of all products. The default category is set to ACCOMM. 
-  `/api/products/{product_id}` : returns detailed response for a product with id `product_id`. 

This PR does not include **Tests**

